### PR TITLE
Fix Http helper cannot work when PHP version greater than 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/src/Http.php
+++ b/src/Http.php
@@ -13,7 +13,7 @@ class Http {
         if (function_exists('curl_init')) {
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_HEADER, false);
-            curl_setopt($ch, CURLOPT_HTTPHEADER, array_key_exists('header', $params) ? $params['header'] : false);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array_key_exists('header', $params) ? $params['header'] : []);
             curl_setopt($ch, CURLOPT_TIMEOUT, array_key_exists('timeout', $params) ? $params['timeout'] : 30);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
@@ -53,7 +53,7 @@ class Http {
         return self::exec($ch);
     }
 
-    public static function post($url, $data = null, $params = null) {
+    public static function post($url, $data = null, $params = []) {
         $ch = self::init($params);
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_POST, true);
@@ -63,7 +63,7 @@ class Http {
         return self::exec($ch);
     }
 
-    public static function postRaw($url, $raw, $params = null) {
+    public static function postRaw($url, $raw, $params = []) {
         $ch = self::init($params);
         curl_setopt($ch, CURLOPT_URL, $url);
         curl_setopt($ch, CURLOPT_POST, true);
@@ -71,7 +71,7 @@ class Http {
         return self::exec($ch);
     }
 
-    public static function postRawSsl($url, $raw, $params = null) {
+    public static function postRawSsl($url, $raw, $params = []) {
         $ch = self::init($params);
         if (!array_key_exists('cert_path', $params) || !array_key_exists('key_path', $params) || !array_key_exists('ca_path', $params)) {
             exception('证书文件路径不能为空');
@@ -85,7 +85,7 @@ class Http {
         return self::exec($ch);
     }
 
-    public static function saveImage($url, $path, $filename = null, $params = null) {
+    public static function saveImage($url, $path, $filename = null, $params = []) {
         $ch  = self::init($params);
         curl_setopt($ch, CURLOPT_URL, $url);
         $img = curl_exec($ch);

--- a/src/Http.php
+++ b/src/Http.php
@@ -9,7 +9,7 @@ namespace anerg\helper;
 
 class Http {
 
-    private static function init($params = null) {
+    private static function init($params = []) {
         if (function_exists('curl_init')) {
             $ch = curl_init();
             curl_setopt($ch, CURLOPT_HEADER, false);


### PR DESCRIPTION
Looks like the 'params' argument's default value must be an array in the  `Http` helper, however null is supplied. it should produce an error: 

> [ error ] [2]array_key_exists() expects parameter 2 to be array, null given[/var/www/html/vendor/anerg2046/helper/src/Http.php:16]
